### PR TITLE
Workarounds for windows plugin

### DIFF
--- a/src/windows/AllJoynProxy.js
+++ b/src/windows/AllJoynProxy.js
@@ -225,6 +225,7 @@ cordova.commandProxy.add("AllJoyn", {
       messageHandler.addHandler(
         joinSessionReplyId, 'uu',
         function(messageObject, messageBody) {
+          messageHandler.removeHandler(joinSessionReplyId, this[1]);
           if (messageBody != null) {
             var sessionId = messageBody[1];
             var sessionHost = service.name;
@@ -233,7 +234,6 @@ cordova.commandProxy.add("AllJoyn", {
             // TODO: How to get the error code, is it in the message header?
             error();
           }
-          messageHandler.removeHandler(joinSessionReplyId, this[1]);
         }
       );
     } else {

--- a/src/windows/AllJoynProxy.js
+++ b/src/windows/AllJoynProxy.js
@@ -227,7 +227,7 @@ cordova.commandProxy.add("AllJoyn", {
         function(messageObject, messageBody) {
           if (messageBody != null) {
             var sessionId = messageBody[1];
-            var sessionHost = messageObject.sender;
+            var sessionHost = service.name;
             success([sessionId, sessionHost]);
           } else {
             // TODO: How to get the error code, is it in the message header?
@@ -302,8 +302,8 @@ cordova.commandProxy.add("AllJoyn", {
         messageHandler.addHandler(
           replyMessageId, responseType,
           function(messageObject, messageBody) {
-            success(messageBody);
             messageHandler.removeHandler(replyMessageId, this[1]);
+            success(messageBody);
           }
         );
       }


### PR DESCRIPTION
- Remove the member invocation callback from the callbacks list before
  invoking the callback. This mitigates the risk of having multiple
  callbacks invoked for the same message type. Which can happen when
  doing chain of property gets chained in the success callbacks of
  each other.
- Also modified the joinSession callback to use the original target
  sender's name as the sessionHost value. It turns out that the sender
  of the session joined reply is actually the router so using this value
  as the target of member invocations is invalid.
