### PR TITLE
Some argument format aligning between iOS and WinRT

### DIFF
--- a/src/ios/AllJoyn_Cordova.m
+++ b/src/ios/AllJoyn_Cordova.m
@@ -880,6 +880,7 @@ uint8_t dbgALLJOYN_CORDOVA = 1;
                 const char* varSig = NULL;
                 marshalStatus.status = AJ_UnmarshalVariant(pMsg, &varSig);
                 if(marshalStatus.status == AJ_OK) {
+                    [values addObject:[NSString stringWithUTF8String:varSig]];
                     // Marshal the actual type
                     marshalStatus.status = [self unmarshalArgumentsFor:pMsg withSignature:[NSString stringWithUTF8String:varSig] toValues:values].status;
                 }


### PR DESCRIPTION
These changes result in the following:
- When a received message contains a variant argument iOS now returns the variant signature as part of the argument list returns. This is what WinRT was doing. 
  
  A simple example of this would be the callback for a property get of type 'n'. All Property gets have a variant return type. So now for both iOS and WinRT the callback should result in an argument value like so (if the property value was 1):
  
  ``` javascript
  ['n', 1]
  ```
- WinRT now returns arrays for nested collections. Previously it was returning the a WinRT projected Vector which has some API parity with JS arrays but not completely. Since it would be better to be exactly the same, and we don't want to expose WinRT types to the app this change now looks at all the arguments (recursively if encountering nested collections) and converts them to arrays. iOS was already returning standard arrays.
  
  Here is an example of what the return looks like now:
  
  ``` javasript
    ["a(qss)", // Signature of variant type (this was a variant property get)
        [ // Container for the array of structure elements
          [0, "Tuner", "Tuner"], // structure element represented as array of 3 values with types q, s and s
          [1, "AV1", "AV 1"],
          [2, "Component1", "Component 1"],
          [3, "HDMI1", "HDMI 1"],
          [4, "HDMI2", "HDMI 2"],
          [5, "HDMI3", "HDMI 3"]
        ]
    ]
  ```

@phongcao and @vjrantal: I'd like your take on the proxy changes.

I've tested this change out with the chat app between iOS and Windows and it seems to work fine (no variants or arrays so didn't really matter. I also tested it with an updated tv sample app and that worked much better (feature party in the app). @phongcao I will test out the lighting sample tomorrow on both WinRT and iOS with these changes. I haven't yet tried the lighting sample on iOS (sorry) so there may be some new issues/differences found when I try that also. But I think this is still progress towards a fully consistent API surface.
