### PR TITLE
Misc. fixes for issues found when validating Lighting sample on iOS and Windows

### DIFF
--- a/src/windows/AllJoynWinRTComponent/AllJoynWinRTComponent.cpp
+++ b/src/windows/AllJoynWinRTComponent/AllJoynWinRTComponent.cpp
@@ -1376,7 +1376,7 @@ void AllJoynWinRTComponent::AllJoyn::AJ_UnmarshalArgsWithDelegate(AJ_Message^ ms
 	PLSTOMBS(signature, _signature);
 	const char* sig = _signature;
 	::AJ_Status _status = UnmarshalArgs(&msg->_msg, &sig, args);
-	func(static_cast<AJ_Status>(_status), (_signature[0] == 'a' && args->Size == 1) ? (Vector<Object^>^)args->GetAt(0) : args);
+	func(static_cast<AJ_Status>(_status), args);
 }
 
 


### PR DESCRIPTION
Fixes include:
- iOS: some Unmarshal fixes around structure unpacking. And proper handling when the destination is not specified
- WinRT: Stop automatically unpacking an array if it is the only argument.
  The goal here is to provide consistency for how values are returned.
  Previously if the return type was 'n' or 'an' with an array of 1 value the callback would always receive an array with one element in it. Now:

```
'n' -> [1]
'an' -> [[1]]
```

We continue to reference the first argument by index 0 into the callback parameter
