### PR TITLE
Return Message Information to Callbacks

### DIFF
--- a/www/alljoyn.js
+++ b/www/alljoyn.js
@@ -17,6 +17,21 @@ var getSignalRuleString = function(member, interface) {
   return "type='signal',member='" + member + "',interface='" + interface + "'";
 };
 
+var wrapMsgInfoReceivingCallback = function(callback) {
+  return function (msgInfoAndArguments) {
+    var msg = {};
+    msg.arguments = msgInfoAndArguments[1];
+    var msgInfo = msgInfoAndArguments[0];
+    for(var msgInfoProp in msgInfo) {
+      if(msgInfo.hasOwnProperty(msgInfoProp)) {
+        msg[msgInfoProp] = msgInfo[msgInfoProp];
+      }
+    }
+    console.log("returning msg: " + JSON.stringify(msg));
+    callback(msg);
+  };
+};
+
 var AllJoyn = {
   connect: function(success, error) {
     var successCallback = function() {
@@ -27,7 +42,8 @@ var AllJoyn = {
           // exec requires it, but it is not used for anything.
           // The listener is also passed as a parameter, because in the Windows implementation, the success callback
           // can't be called multiple times.
-          exec(listener, function() {}, "AllJoyn", "addListener", [indexList, responseType, listener]);
+          var wrappedListener = wrapMsgInfoReceivingCallback(listener);
+          exec(wrappedListener, function() {}, "AllJoyn", "addListener", [indexList, responseType, wrappedListener]);
         },
         // joinSessionRequest = {
         //   port: 12,
@@ -51,10 +67,68 @@ var AllJoyn = {
          * When name found, listener is called with parameter { name: "the.name.found" }
          */
         addAdvertisedNameListener: function(name, listener) {
-          exec(listener, function() {}, "AllJoyn", "addAdvertisedNameListener", [name, listener]);
+          var getAdvertisedNameObject = function(message) {
+            return {
+              message: message,
+              name: message.arguments.name,
+            };
+          };
+          var wrappedListener = wrapMsgInfoReceivingCallback(function(message) {
+            listener(getAdvertisedNameObject(message));
+          });
+          exec(wrappedListener, function() {}, "AllJoyn", "addAdvertisedNameListener", [name, wrappedListener]);
         },
         addInterfacesListener: function(interfaceNames, listener) {
-          exec(listener, function() {}, "AllJoyn", "addInterfacesListener", [interfaceNames, listener]);
+          var aboutAnnouncementRule = "interface='org.alljoyn.About',sessionless='t'";
+          if (interfaceNames) {
+            if (interfaceNames.constructor !== Array) {
+              interfaceNames = [interfaceNames];
+            }
+            interfaceNames.forEach(function(currentValue, index, array) {
+              aboutAnnouncementRule += ",implements='" + currentValue + "'";
+            });
+          }
+
+          console.log('aboutAnnouncementRule: ' + aboutAnnouncementRule);
+          var onAboutAnnouncementReceived = function(message) {
+            var aboutAnnouncement = {};
+            aboutAnnouncement.message = message;
+            console.log('onAboutAnnouncementReceived: ' + JSON.stringify(arguments));
+            if (message && message.arguments) {
+              var msgArgs = message.arguments;
+              if (msgArgs[0] !== undefined) {
+                aboutAnnouncement.version = msgArgs[0];
+              }
+              if (msgArgs[1] !== undefined) {
+                aboutAnnouncement.port = msgArgs[1];
+              }
+              if (msgArgs[2] && msgArgs[2].constructor === Array) {
+                aboutAnnouncement.objects = [];
+                msgArgs[2].forEach(function(objectDescription) {
+                  if (objectDescription.constructor === Array) {
+                    var object = {};
+                    object.path = objectDescription[0];
+                    object.interfaces = objectDescription[1];
+                    aboutAnnouncement.objects.push(object);
+                  }
+                });
+              }
+              if (msgArgs[3] && msgArgs[3].constructor === Array) {
+                msgArgs[3].forEach(function(objectProperty) {
+                  if (objectProperty.constructor === Array) {
+                    aboutAnnouncement[objectProperty.shift()] = objectProperty;
+                  }
+                });
+              }
+            }
+            console.log('AboutAnnouncement: ' + JSON.stringify(aboutAnnouncement));
+            listener(aboutAnnouncement);
+          };
+          var onAddAboutAnnouncementRuleSuccess = function() {
+            var aboutAnnouncementIndexList = [0, 5, 1, 3]; // AJ_SIGNAL_ABOUT_ANNOUNCE
+            bus.addListener(aboutAnnouncementIndexList, 'qqa(oas)a{sv}', onAboutAnnouncementReceived);
+          };
+          exec(onAddAboutAnnouncementRuleSuccess, function() {}, "AllJoyn", "setSignalRule", [aboutAnnouncementRule, 0]);
         },
         startAdvertisingName: function(success, error, name, port) {
           exec(success, error, "AllJoyn", "startAdvertisingName", [name, port]);
@@ -69,15 +143,17 @@ var AllJoyn = {
               };
          */
         joinSession: function(success, error, service) {
-          var successCallback = function(result) {
-            var sessionId = result[0];
-            var sessionHost = result[1];
+          var successCallback = function(msg) {
+            var sessionId = msg.arguments[0];
+            var sessionHost = msg.arguments[1];
             var session = {
               sessionId: sessionId,
               sessionHost: sessionHost,
+              message: msg,
               callMethod: function(callMethodSuccess, callMethodError, destination, path, indexList, inParameterType, parameters, outParameterType) {
                 var signature = getSignature(indexList, registeredObjects);
-                exec(callMethodSuccess, callMethodError, "AllJoyn", "invokeMember", [sessionId, destination, signature, path, indexList, inParameterType, parameters, outParameterType]);
+                var wrappedSuccessCallback = wrapMsgInfoReceivingCallback(callMethodSuccess);
+                exec(wrappedSuccessCallback, callMethodError, "AllJoyn", "invokeMember", [sessionId, destination, signature, path, indexList, inParameterType, parameters, outParameterType]);
               },
               sendSignal: function(sendSignalSuccess, sendSignalError, destination, path, indexList, inParameterType, parameters) {
                 var signature = getSignature(indexList, registeredObjects);
@@ -89,8 +165,8 @@ var AllJoyn = {
             };
             success(session);
           };
-
-          exec(successCallback, error, "AllJoyn", "joinSession", [service]);
+          var wrappedSuccessCallback = wrapMsgInfoReceivingCallback(successCallback);
+          exec(wrappedSuccessCallback, error, "AllJoyn", "joinSession", [service]);
         },
         sendSignal: function(sendSignalSuccess, sendSignalError, indexList, inParameterType, parameters) {
           var signature = getSignature(indexList, registeredObjects);
@@ -102,7 +178,7 @@ var AllJoyn = {
         var getClass = {}.toString;
         var responseCallback = function(response) {
           exec(function() {}, function() {}, "AllJoyn", "replyAcceptSession", [messagePointer, response]);
-          if(doneCallback && getClass.call(doneCallback) == '[object Function]') {
+          if (doneCallback && getClass.call(doneCallback) == '[object Function]') {
             doneCallback();
           }
         };

--- a/www/alljoyn.js
+++ b/www/alljoyn.js
@@ -18,12 +18,12 @@ var getSignalRuleString = function(member, interface) {
 };
 
 var wrapMsgInfoReceivingCallback = function(callback) {
-  return function (msgInfoAndArguments) {
+  return function(msgInfoAndArguments) {
     var msg = {};
     msg.arguments = msgInfoAndArguments[1];
     var msgInfo = msgInfoAndArguments[0];
-    for(var msgInfoProp in msgInfo) {
-      if(msgInfo.hasOwnProperty(msgInfoProp)) {
+    for (var msgInfoProp in msgInfo) {
+      if (msgInfo.hasOwnProperty(msgInfoProp)) {
         msg[msgInfoProp] = msgInfo[msgInfoProp];
       }
     }
@@ -91,8 +91,11 @@ var AllJoyn = {
 
           console.log('aboutAnnouncementRule: ' + aboutAnnouncementRule);
           var onAboutAnnouncementReceived = function(message) {
-            var aboutAnnouncement = {};
-            aboutAnnouncement.message = message;
+            var aboutAnnouncement = {
+              message: message, // Original announcement message
+              objects: [], // Holds the object descriptions
+              properties: {}, // Properties from the announcement
+            };
             console.log('onAboutAnnouncementReceived: ' + JSON.stringify(arguments));
             if (message && message.arguments) {
               var msgArgs = message.arguments;
@@ -102,8 +105,10 @@ var AllJoyn = {
               if (msgArgs[1] !== undefined) {
                 aboutAnnouncement.port = msgArgs[1];
               }
+
+              // Get the object description from the announcement
+              // the 'a(oas)' part of the signature
               if (msgArgs[2] && msgArgs[2].constructor === Array) {
-                aboutAnnouncement.objects = [];
                 msgArgs[2].forEach(function(objectDescription) {
                   if (objectDescription.constructor === Array) {
                     var object = {};
@@ -113,10 +118,13 @@ var AllJoyn = {
                   }
                 });
               }
+
+              // Get the properties from the announcement
+              // the 'a{sv}' part of the signature
               if (msgArgs[3] && msgArgs[3].constructor === Array) {
                 msgArgs[3].forEach(function(objectProperty) {
                   if (objectProperty.constructor === Array) {
-                    aboutAnnouncement[objectProperty.shift()] = objectProperty;
+                    aboutAnnouncement.properties[objectProperty.shift()] = objectProperty;
                   }
                 });
               }


### PR DESCRIPTION
This is a **proposal** for one way we might return message information to
the application registered callbacks/listeners. I definitely want folks feedback before this goes in.
- This method returns a message information object as a 2nd parameter to the application callbacks. 
- The msg information is limited to a few fields now but this can easily changed
- The advantage of this implementation is that it doesn't require changes for our existing apps. 
- This first pass only touches success callbacks that were receiving arguments. When we decide on the way we want to do this we should then make it generic and return it for all message backed callbacks as well as for errors.

The change is spread across two layers:

Native/Proxy layer:
- Where this layer used to just return an array of arguments for the
  callback it now returns an array of two values. The first value is a
  dictionary structure representing the message that resulted in the
  callback. The second value is the argument array that we used to
  return

AllJoyn.js layer:
- Because of the changes in the native/proxy layer we now wrap all
  callback methods that receive this new message info & argument array.
  The wrapper splits up the message info and calls the callback with the
  argument array in the first parameter (parity with existing behavior)
  and the msg info object as the 2nd parameter.

Here is a rough example of how this change might be used:
In the chat sample we can have code like this:

``` javascript
        var chatMessageHandler = function(response, msgInfo) {
          if (channelsModel.currentChannel == null) return;
          var message = new Message(response[0], msgInfo.sender);
          channelsModel.currentChannel.messages.push(message);
          broadcastOnRootScope('newMessage', message);
        }
```

Which will have a result like this:
![chat_with_sender](https://cloud.githubusercontent.com/assets/666628/6312411/30e3b72c-b92c-11e4-9631-032c6f37b893.jpg)
