### PR TITLE
Add Internet (Client & Server) capability.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -191,6 +191,12 @@
         </js-module>
         <framework src="src/windows/AllJoynWinRTComponent/AllJoynWinRTComponent.Windows.vcxproj" custom="true" type="projectReference" target="windows" />
         <framework src="src/windows/AllJoynWinRTComponent/AllJoynWinRTComponent.WindowsPhone.vcxproj" custom="true" type="projectReference" target="phone" />
+        <config-file target="package.windows80.appxmanifest" parent="/Package/Capabilities">
+            <Capability Name="internetClientServer" />
+        </config-file>
+        <config-file target="package.windows.appxmanifest" parent="/Package/Capabilities">
+            <Capability Name="internetClientServer" />
+        </config-file>
     </platform>
 
 </plugin>


### PR DESCRIPTION
This capability is required in the Windows Store apps for AllJoyn connections
to work.

This capability should be automatically added if app is run from Visual Studio,
but it seems like this is not the case at least always. This commit is at least
required when app is run with Cordova scripts.

Addresses issue #14.
