### PR TITLE
Fix for re-connect after connection failure crash.

### DIFF
--- a/src/ios/AllJoyn_Cordova.m
+++ b/src/ios/AllJoyn_Cordova.m
@@ -91,10 +91,12 @@ uint8_t dbgALLJOYN_CORDOVA = 1;
             if(status == AJ_OK) {
                 [self setConnectedToBus:true];
                 [self sendSuccessMessage:@"Connected" toCallback:[command callbackId] withKeepCallback:false];
+                 printf("\n\nStarted!\n");
             } else {
                 [self sendErrorMessage:@"Failed to connect" toCallback:[command callbackId] withKeepCallback:false];
+                dispatch_suspend([self dispatchSource]);
+                printf("\n\nNot Started.\n");
             }
-            printf("\n\nStarted!\n");
         }
     }];
 }


### PR DESCRIPTION
The dispatchSource is now suspended on a failure to connect. This appears to fix the crash observed when attempting to re-connect after failure.
