### PR TITLE
Switch into build-only CI verification.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ install:
   - npm install
 script:
   - grunt test
-  - npm test
+  - npm run build-only

--- a/README.md
+++ b/README.md
@@ -82,14 +82,16 @@ $ cordova run android
 Running Tests
 -------------
 
-The iOS tests can be run locally with:
+The tests can be run locally with:
 
 ```
 $ npm install
 $ npm test
 ```
 
-With above commands, the tests are run on real device if Cordova scripts find one or in simulator if device not found
+An AllJoyn router must be accessible in the network in which the target device runs for the tests to pass.
+
+The target platform will be selected automatically based on which platform the tests are run. On Mac, an iOS build is made. On Windows, the Cordova universal Windows platform is used and on Linux, the build will be targeting Android. To switch the target, one needs to edit the variable  cordovaPlatformMapping at the top of file tests/run.js.
 
 To run tests on Windows, first ensure that fresh enough Cordova script is found from the path. You can look at appveyor.yml file from the root of this repository how this is done in the CI environment. You can use where command to check which cordova is found first from your path:
 
@@ -97,16 +99,8 @@ To run tests on Windows, first ensure that fresh enough Cordova script is found 
 $ where cordova
 ```
 
-Then, in the root of the repository:
+If you only want to verify that the build is working via Cordova scripts, you can run:
 
 ```
-$ npm install
-$ set PATH=%cd%\node_modules\.bin;%PATH%
-$ cordova-paramedic --platform windows --plugin %cd% --tempProjectPath %tmp%\testApp --architecture=x86 --phone=true
-```
-
-Above runs the tests on a Windows Phone emulator. To run on real device, make sure it is connected and run:
-
-```
-$ cordova-paramedic --platform windows --plugin %cd% --tempProjectPath %tmp%\testApp --architecture=arm --phone=true --device=true
+$ npm run build-only
 ```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,9 @@
 clone_folder: c:\projects\cordova-plugin-alljoyn
 
 install:
-  - npm install -g grunt-cli
   - npm install
 
 build: off
 
 test_script:
-  - grunt test
-  - npm test
+  - npm run build-only

--- a/circle.yml
+++ b/circle.yml
@@ -12,3 +12,5 @@ test:
         background: true
         parallel: true
     - circle-android wait-for-boot
+  override:
+    - npm run build-only

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
         "url": "https://github.com/AllJoyn-Cordova/cordova-plugin-alljoyn.git"
     },
     "scripts": {
-        "test": "node tests/run.js"
+        "test": "node tests/run.js",
+        "build-only": "node tests/run.js build-only"
     },
     "devDependencies": {
         "cordova": "^4.3.0",

--- a/tests/run.js
+++ b/tests/run.js
@@ -8,8 +8,11 @@ var cordovaPlatformMapping = {
 };
 var cordovaPlatform = cordovaPlatformMapping[platform];
 
-// Load alljoyn only on Mac and Linux since it doesn't build on Windows
-var alljoyn = (platform === 'darwin' || platform === 'linux') && require('alljoyn') || null;
+var buildOnly = process.argv[2] === 'build-only';
+var requestRouter = process.argv[2] === 'request-router';
+
+// Require alljoyn only if a router is requested
+var alljoyn = requestRouter && require('alljoyn') || null;
 var path = require('path');
 var os = require('os');
 var spawn = require('child_process').spawn;
@@ -38,7 +41,7 @@ var runRouter = function () {
     bus.connect();
 };
 
-if (platform === 'darwin' || platform === 'linux') {
+if (requestRouter) {
     runRouter();
 }
 
@@ -56,7 +59,7 @@ var parameticArguments = [
     '--removeTempProject=true'
 ];
 
-if (platform === 'win32' || platform === 'linux') {
+if (buildOnly) {
     parameticArguments.push('--buildOnly=true');
 }
 


### PR DESCRIPTION
Travis builds have become unreliable when tests are executed against the
AllJoyn router. Once a solution is found, test execution will be re-enabled.

Removed the "grunt test" step from AppVeyor, because it is enough that coding
conventions is checked by one CI and that is already done by Travis.
