### PR TITLE
Updated building system to support Apache Cordova Android 4.0.0.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,9 @@
 
     <!-- android -->
     <platform name="android">
+		<hook type="after_platform_add" src="scripts/androidUpdateSettings.js" />
 		<hook type="before_build" src="scripts/androidBeforeBuild.js" />
+		<hook type="after_build" src="scripts/androidUpdateSettings.js" />
 
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="AllJoyn">
@@ -143,7 +145,6 @@
 		
 		<!-- gradle -->
 		<source-file src="src/android/gradle/build.gradle" target-dir="AllJoynLib" />
-		<source-file src="src/android/gradle/settings.gradle" target-dir="." />
 		<source-file src="src/android/gradle/AndroidManifest.xml" target-dir="AllJoynLib/src/main" />
     </platform>
    

--- a/scripts/androidUpdateSettings.js
+++ b/scripts/androidUpdateSettings.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+var path = require('path');
+var fs = require('fs');
+var sys = require('sys');
+var exec = require('child_process').exec;
+
+module.exports = function (context) {
+    var Q = context.requireCordovaModule('q');
+    var deferral = new Q.defer();
+    var settingsFileName = path.join('platforms', 'android', 'settings.gradle');
+    var settingsFile = fs.openSync(settingsFileName, 'a');
+
+    if (settingsFile) {
+        fs.writeSync(settingsFile, 'include ":AllJoynLib"');
+        fs.closeSync(settingsFile);
+    } else {
+        console.log('settings.gradle not found.');
+    }
+
+    deferral.resolve();
+    return deferral.promise;
+};

--- a/src/android/gradle/settings.gradle
+++ b/src/android/gradle/settings.gradle
@@ -1,1 +1,0 @@
-include ':AllJoynLib'


### PR DESCRIPTION
Since the release of Apache Cordova Android 4.0.0, all builds use Gradle by default instead of Ant. This creates a conflict in settings.gradle file. Therefore, this update uses another custom script in order to update the settings file generated by Cordova building system. It's used whenever there is a platform add or cordova build call.
