### PR TITLE
Update the swig version used in the CI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ There are some external dependencies when building the plugin for the Android pl
 $ brew install ant gradle swig
 ```
 
+The swig version needs to be 3.0 or higher.
+
 After dependencies are met, the steps to build and run are something like:
 
 ```

--- a/circle.yml
+++ b/circle.yml
@@ -4,13 +4,12 @@ machine:
 
 dependencies:
   pre:
-    - sudo add-apt-repository -y ppa:cwchien/gradle; sudo apt-get update -y; sudo apt-get install -y swig gradle
+    - sudo add-apt-repository -y ppa:cwchien/gradle
+    - sudo add-apt-repository -y ppa:teward/swig3.0
+    - sudo apt-get update -y
+    - sudo apt-get install -y swig3.0 gradle
+    - sudo ln -sf /usr/bin/swig3.0 /usr/bin/swig
 
 test:
-  pre:
-    - emulator -avd circleci-android21 -no-audio -no-window:
-        background: true
-        parallel: true
-    - circle-android wait-for-boot
   override:
     - npm run build-only


### PR DESCRIPTION
This is done, because the build started failing with older version of swig.

This closes #50.

The emulator boot wait for also removed, because it is not needed as long as
we are doing a build-only verification.
