### PR TITLE
android: make build hooks working w/ IDEs

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -22,8 +22,8 @@
     <!-- android -->
     <platform name="android">
 		<hook type="after_platform_add" src="scripts/androidUpdateSettings.js" />
-		<hook type="before_build" src="scripts/androidBeforeBuild.js" />
-		<hook type="after_build" src="scripts/androidUpdateSettings.js" />
+		<hook type="before_compile" src="scripts/androidBeforeBuild.js" />
+		<hook type="after_compile" src="scripts/androidUpdateSettings.js" />
 
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="AllJoyn">


### PR DESCRIPTION
Several IDEs (@VSCordovaTools as an example) call `cordova compile` instead of `cordova build` internally to skip prepare step. In this case `before/after_build` hooks are not called. `before/after_compile` hooks are more robust and guaranteed to be called.
