### PR TITLE
Update invalid engine reference

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -9,7 +9,7 @@
 
     <engines>
         <engine name="cordova" version=">=3.1.0" />
-        <engine name="cordova-windows8" version=">=3.8.0" />
+        <engine name="cordova-windows" version=">=3.8.0" />
     </engines>
 
     <js-module src="www/AllJoyn.js" name="AllJoyn">


### PR DESCRIPTION
Looks like this might resolve #60

List of engines [here](https://cordova.apache.org/docs/en/latest/plugin_ref/spec.html) does not include `cordova-windows8`.
